### PR TITLE
fix UnicodeDecodeError in signin_accounts.py when using python verison 3.14.5

### DIFF
--- a/signin_accounts.py
+++ b/signin_accounts.py
@@ -33,6 +33,7 @@ def main():
                     password,
                 ],
                 universal_newlines=True,
+                encoding="utf-8",
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )


### PR DESCRIPTION
Basically when using the signin_accounts.py with python verison 3.14.5, I got a "UnicodeDecodeError", and then adding that line fixed it, im not sure if adding that line will break other python verisons, but you can test it if you want, it's only 1 line