### PR TITLE
fix: correct Successefully to Successfully in account registration message

### DIFF
--- a/generate_accounts.py
+++ b/generate_accounts.py
@@ -162,7 +162,7 @@ class MegaAccount:
             universal_newlines=True,
         )
         if "registered successfully!" in str(verification.stdout):
-            print(f"\r> [{self.email}] Successefully registered and verified.", end="\033[K", flush=True)
+            print(f"\r> [{self.email}] Successfully registered and verified.", end="\033[K", flush=True)
             print(f"\n{self.email} - {self.password}")
 
             # save to file


### PR DESCRIPTION
## Summary
Fix typo in generate_accounts.py line 165: 'Successefully registered and verified' → 'Successfully registered and verified' in user-facing print message shown after successful account registration.

## Fix
- generate_accounts.py: print("**Successfully** registered and verified.") - User-facing message shown after account verification completes

## Testing
- Syntax check: python3 -m py_compile generate_accounts.py ✅